### PR TITLE
Fix: Improve location fetching and soil data handling

### DIFF
--- a/components/contextual/EnvironmentalSection.tsx
+++ b/components/contextual/EnvironmentalSection.tsx
@@ -50,18 +50,32 @@ const EnvironmentalSection: React.FC = () => {
   const renderEnvironmentalDataContent = () => {
     if (isLoadingEnvironmental && !environmentalData) return <EnvironmentalDataSkeleton />;
     
-    const noEnvData = !environmentalData || (!environmentalData.elevation && !environmentalData.soilPH && !environmentalData.soilOrganicCarbon && !environmentalData.soilCEC && !environmentalData.soilNitrogen && !environmentalData.soilSand && !environmentalData.soilSilt && !environmentalData.soilClay && !environmentalData.soilAWC && !environmentalData.error);
-    
-    if (environmentalData?.error && noEnvData) {
+    // Prioritize displaying specific error messages
+    if (environmentalData?.error) {
         return (
              <div className="flex flex-col items-center justify-center text-center p-4 h-full bg-[var(--status-red-bg)] rounded-lg border border-[var(--status-red)]">
                 <ExclamationTriangleIcon className="w-12 h-12 text-[var(--status-red-text)] mb-3" />
                 <p className="text-md font-semibold text-[var(--status-red-text)]">{uiStrings.errorTitle}</p>
-                <p className="text-sm text-[var(--status-red-text)] opacity-90 mt-1">{environmentalData.error}</p>
+                {/* Using a generic message for soil data errors as specific error details might be too technical or already part of environmentalData.error string from the service */}
+                <p className="text-sm text-[var(--status-red-text)] opacity-90 mt-1">{uiStrings.soilDataErrorGeneral || "Could not retrieve soil data. Please check your connection or try again."}</p>
             </div>
         );
     }
+
+    const noEnvData = !environmentalData || (!environmentalData.elevation && !environmentalData.soilPH && !environmentalData.soilOrganicCarbon && !environmentalData.soilCEC && !environmentalData.soilNitrogen && !environmentalData.soilSand && !environmentalData.soilSilt && !environmentalData.soilClay && !environmentalData.soilAWC);
+
     if (noEnvData && !isLoadingEnvironmental) {
+        // Specific message if SoilGrids indicates no data for the location
+        if (environmentalData?.source === 'SoilGrids (NoDataAtLocation)') {
+            return (
+                <div className="flex flex-col items-center justify-center text-center p-4 h-full bg-[var(--glass-bg-secondary)] rounded-lg border border-[var(--glass-border)]">
+                    <ExclamationTriangleIcon className="w-12 h-12 text-[var(--status-yellow-text)] mb-3" />
+                    <p className="text-md font-semibold text-[var(--text-headings)]">{uiStrings.soilDataNotAvailableForLocationTitle || "Soil Data Not Available"}</p>
+                    <p className="text-xs text-[var(--text-secondary)] mt-1">{uiStrings.soilDataNotAvailableForLocation || "Soil data is not available for this specific location from our provider."}</p>
+                </div>
+            );
+        }
+        // Fallback general unavailable message
         return (
             <div className="flex flex-col items-center justify-center text-center p-4 h-full bg-[var(--glass-bg-secondary)] rounded-lg border border-[var(--glass-border)]">
                 <ExclamationTriangleIcon className="w-12 h-12 text-[var(--status-yellow-text)] mb-3" />

--- a/fedai-backend-proxy/src/api/controllers/data.controller.js
+++ b/fedai-backend-proxy/src/api/controllers/data.controller.js
@@ -231,7 +231,7 @@ const getSoilData = async (req, res) => {
     const soilGridsApiUrl = `${SOILGRIDS_API_URL_PREFIX}?lon=${longitude}&lat=${latitude}&property=${properties}&depth=${depths}&value=${valueType}`;
     
     try {
-        const data = await robustFetch(soilGridsApiUrl, {}, GEOLOCATION_API_TIMEOUT_MS + 3000);
+        const data = await robustFetch(soilGridsApiUrl, {}, GEOLOCATION_API_TIMEOUT_MS + 6000);
         
         const soilProps = {};
         let wv0033_value = null;

--- a/hooks/useLocationLogic.ts
+++ b/hooks/useLocationLogic.ts
@@ -103,7 +103,7 @@ export function useLocationLogic() {
         setIsLoadingLocation(false);
         fetchIpLocationData(false); 
       },
-      { enableHighAccuracy: true, timeout: GEOLOCATION_HIGH_ACCURACY_TIMEOUT_MS, maximumAge: GEOLOCATION_MAXIMUM_AGE_MS }
+      { enableHighAccuracy: false, timeout: 5000, maximumAge: GEOLOCATION_MAXIMUM_AGE_MS }
     );
   }, [uiStrings, fetchIpLocationData]);
 


### PR DESCRIPTION
This commit addresses issues related to location permission/retrieval and soil data functionality.

Location:
- Reduced `navigator.geolocation.getCurrentPosition` timeout from 10s to 5s in `hooks/useLocationLogic.ts`.
- Set `enableHighAccuracy` to `false` for faster, though potentially less precise, location acquisition. This aims to improve your experience on mobile devices where quick feedback is crucial. IP-based location remains as a fallback.

Soil Data:
- Increased the timeout for fetching soil data from SoilGrids in the backend proxy (`fedai-backend-proxy/src/api/controllers/data.controller.js`) from 10s to 13s to make it more resilient to slow API responses.
- Refined frontend messages in `components/contextual/EnvironmentalSection.tsx` to provide clearer feedback to you:
    - Displays "Could not retrieve soil data. Please check your connection or try again." if there's a general fetch error.
    - Displays "Soil data is not available for this specific location from our provider." if SoilGrids explicitly reports no data for the given coordinates.