### PR TITLE
Refactor: Further optimize location fetching flow

### DIFF
--- a/fedai-backend-proxy/src/api/controllers/data.controller.js
+++ b/fedai-backend-proxy/src/api/controllers/data.controller.js
@@ -19,7 +19,7 @@ const getIpLocation = async (req, res) => {
   try {
     // Try primary service: ipapi.co
     try {
-      const data = await robustFetch(IPAPI_CO_URL, { headers: { 'User-Agent': 'FedaiProxy/1.0' } });
+      const data = await robustFetch(IPAPI_CO_URL, { headers: { 'User-Agent': 'FedaiProxy/1.0' } }, 3500);
       if (!data.error && data.latitude && data.longitude) {
         return res.json({
           latitude: data.latitude,
@@ -37,7 +37,7 @@ const getIpLocation = async (req, res) => {
     }
 
     // Try secondary service: ip-api.com
-    const dataFallback = await robustFetch(IP_API_COM_URL, { headers: { 'User-Agent': 'FedaiProxy/1.0' } });
+    const dataFallback = await robustFetch(IP_API_COM_URL, { headers: { 'User-Agent': 'FedaiProxy/1.0' } }, 3500);
     if (dataFallback.status === 'success' && dataFallback.lat && dataFallback.lon) {
       return res.json({
         latitude: dataFallback.lat,


### PR DESCRIPTION
This commit introduces further optimizations to the location fetching process to address persistent slowness.

Key changes:

1.  Frontend (`hooks/useLocationLogic.ts`):
    *   Reduced the timeout for `navigator.geolocation.getCurrentPosition`
        (GPS attempt) from 5 seconds to 3 seconds.
    *   Ensured that IP-based location fetching (`fetchIpLocationData(true)`)
        is initiated in parallel with the GPS attempt for enrichment
        purposes when location permission is granted or requested. This
        allows for a faster display of at least an approximate location
        if GPS is slow.

2.  Backend Proxy (`fedai-backend-proxy/src/api/controllers/data.controller.js`):
    *   Set explicit, shorter timeouts for the internal `robustFetch` calls
        within the `getIpLocation` controller. Each of the two external
        IP lookup services (`ipapi.co`, `ip-api.com`) is now called with
        a 3.5-second timeout. This reduces the maximum potential delay
        in the proxy for IP lookups from ~14 seconds to ~7 seconds.

These changes aim to significantly improve the responsiveness of location determination and reduce your frustration caused by long waits.