### PR TITLE
feat: Implement automatic location fetching and scroll to results

### DIFF
--- a/components/AnalysisFlowController.tsx
+++ b/components/AnalysisFlowController.tsx
@@ -47,6 +47,7 @@ const AnalysisFlowController: React.FC = () => {
   const pipelineModalContentRef = useRef<HTMLDivElement>(null);
   const followUpSectionRef = useRef<HTMLDivElement>(null);
   const contextualDataGroupRef = useRef<HTMLDivElement>(null); 
+  const resultsSectionRef = useRef<HTMLDivElement>(null); // Ref for disease results section
 
   const showContextualSections = !!imageFile; 
 
@@ -81,6 +82,13 @@ const AnalysisFlowController: React.FC = () => {
     'textarea',
     150
   );
+
+  // useEffect for scrolling to results section
+  useEffect(() => {
+    if (diseaseInfo && !isLoadingAnalysis && resultsSectionRef.current) {
+      resultsSectionRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [diseaseInfo, isLoadingAnalysis]);
 
 
   return (
@@ -165,14 +173,15 @@ const AnalysisFlowController: React.FC = () => {
       )}
       
       {diseaseInfo && !isLoadingAnalysis && (
-        <BounceIn className="mt-8">
-          <MemoizedDiseaseResultCard result={diseaseInfo} />
-          
-          {diseaseInfo.followUpQuestion && (
-            <div ref={followUpSectionRef} className="card mt-6 p-6 bg-glass space-y-4"> 
-              <h3 className="text-xl font-semibold text-[var(--text-headings)] flex items-center">
-                <ChatBubbleLeftRightIcon className="w-6 h-6 mr-2.5 text-[var(--accent-teal)]" /> 
-                {uiStrings.followUpQuestionLabel}
+        <div ref={resultsSectionRef} className="mt-8"> {/* Attach ref and move className */}
+          <BounceIn>
+            <MemoizedDiseaseResultCard result={diseaseInfo} />
+
+            {diseaseInfo.followUpQuestion && (
+              <div ref={followUpSectionRef} className="card mt-6 p-6 bg-glass space-y-4">
+                <h3 className="text-xl font-semibold text-[var(--text-headings)] flex items-center">
+                  <ChatBubbleLeftRightIcon className="w-6 h-6 mr-2.5 text-[var(--accent-teal)]" />
+                  {uiStrings.followUpQuestionLabel}
               </h3>
               <p className="text-[var(--text-primary)] text-base leading-relaxed">{diseaseInfo.followUpQuestion}</p>
               <textarea
@@ -193,7 +202,8 @@ const AnalysisFlowController: React.FC = () => {
               </button>
             </div>
           )}
-        </BounceIn>
+          </BounceIn>
+        </div>
       )}
     </div>
   );

--- a/components/LocationSection.tsx
+++ b/components/LocationSection.tsx
@@ -38,26 +38,25 @@ const LocationSection: React.FC = () => {
           </Tooltip>
         </h2>
       </div>
-      {locationPermission === 'prompt' && (
-        <div className="space-y-4">
-          <p className="location-prompt-card text-sm p-4 rounded-md">{uiStrings.locationPermissionPromptMessage}</p>
-          <button
-            onClick={requestLocationPermission}
-            className="btn btn-primary w-full text-sm py-2.5"
-            disabled={isLoadingLocation}
-            aria-label={uiStrings.requestLocationPermissionButton}
-          >
-            {isLoadingLocation ? <LoadingSpinner className="w-4 h-4 inline mr-2" /> : null}
-            {uiStrings.requestLocationPermissionButton}
-          </button>
-        </div>
-      )}
+      {/*
+        The button and specific message for 'prompt' state are removed.
+        The component now relies on locationStatusMessage from the context
+        to inform the user about automatic location fetching attempts.
+      */}
       {locationStatusMessage && (
          <div 
            className={`text-sm p-1 ${determineLocationMessageColor()} flex items-center`}
            aria-live="polite"
            aria-atomic="true"
          >
+          {/*
+            The condition for the spinner is kept as is.
+            When locationPermission is 'prompt', isLoadingLocation will be true due to automatic fetching,
+            and locationStatusMessage will display "Attempting to automatically fetch..." or similar.
+            If a spinner is desired *specifically next to this message* during 'prompt',
+            the condition `locationPermission !== 'prompt'` would need adjustment.
+            For now, the global loading state handled by isLoadingLocation should be sufficient.
+          */}
           {isLoadingLocation && locationPermission !== 'prompt' && <LoadingSpinner className="w-4 h-4 inline mr-2" />}
           <span>{locationStatusMessage}</span>
         </div>


### PR DESCRIPTION
I've implemented two UX enhancements based on your feedback:

1.  **Automatic Location Fetching:**
    *   `hooks/useLocationLogic.ts` now automatically initiates an IP-based location fetch upon application load to quickly obtain a coarse location.
    *   It then attempts to acquire a precise GPS-based location. If the browser permission is 'prompt', it now automatically triggers the permission dialog.
    *   User feedback messages (`locationStatusMessage`) have been refined to provide a clearer, step-by-step status of this multi-stage fetching process (e.g., "Fetching approximate location...", "Attempting to get precise location...").
    *   `components/LocationSection.tsx` has been updated to remove the manual "Request Location Permission" button, as the process is now automatic. It passively displays the location fetching status.

2.  **Automatic Scrolling to Analysis Results:**
    *   In `components/AnalysisFlowController.tsx`, when disease analysis results are successfully fetched and displayed, the page now automatically scrolls smoothly to bring the results card to the center of the viewport. This ensures you immediately see that the results are ready.
    *   This was achieved by adding a `ref` to the results section and using a `useEffect` hook to trigger `scrollIntoView()`.

These changes aim to improve the application's user experience by making location acquisition more proactive and ensuring analysis results are immediately visible.