### PR TITLE
feat: Add /api/ip-location endpoint

### DIFF
--- a/pages/api/ip-location.ts
+++ b/pages/api/ip-location.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const ipRes = await fetch('https://ipapi.co/json/');
+    const data = await ipRes.json();
+    res.status(200).json({
+      latitude: data.latitude,
+      longitude: data.longitude,
+      city: data.city,
+      country: data.country_name,
+      countryCode: data.country_code,
+      serviceName: 'ipapi.co'
+    });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch IP location' });
+  }
+}


### PR DESCRIPTION
This commit introduces a new API endpoint at /api/ip-location. This endpoint fetches IP-based geolocation data from the external service ipapi.co.

The frontend relies on this endpoint to provide location-aware features. Its absence was causing timeouts and preventing you from utilizing these features.

The new endpoint handles potential errors during the fetch operation and returns a standardized JSON response containing latitude, longitude, city, country, country code, and the service name.