### PR TITLE
Fix: Improve location and soil service reliability and error handling

### DIFF
--- a/hooks/useContextualData.ts
+++ b/hooks/useContextualData.ts
@@ -64,25 +64,71 @@ export function useContextualData(userLocation: UserLocation | null) {
         const soilPromise = fetchSoilData(userLocation);
 
         const envPromise = Promise.all([elevPromise, soilPromise]).then(([elevation, soil]) => {
-            const envDataToSet: EnvironmentalData = { dataTimestamp: new Date().toISOString(), errorKey: null };
-            if (elevation) envDataToSet.elevation = elevation;
+            const envDataToSet: EnvironmentalData = {
+                dataTimestamp: new Date().toISOString(),
+                errorKey: null,
+                soilErrorDetail: undefined
+            };
+
+            // Process elevation data
+            if (elevation?.elevation) {
+                envDataToSet.elevation = elevation.elevation;
+            }
+
+            // Process soil data
             if (soil) {
-                envDataToSet.soilPH = soil.soilPH;
-                envDataToSet.soilOrganicCarbon = soil.soilOrganicCarbon;
-                envDataToSet.soilCEC = soil.soilCEC;
-                envDataToSet.soilNitrogen = soil.soilNitrogen;
-                envDataToSet.soilSand = soil.soilSand;
-                envDataToSet.soilSilt = soil.soilSilt;
-                envDataToSet.soilClay = soil.soilClay;
-                envDataToSet.soilAWC = soil.soilAWC;
+                if (soil.error) {
+                    envDataToSet.errorKey = 'soilDataFetchError';
+                    envDataToSet.soilErrorDetail = soil.error;
+                    // Potentially still assign any partial data if the structure allows, though unlikely with an error
+                    if (soil.soilPH) envDataToSet.soilPH = soil.soilPH;
+                    // Add other properties if they might exist despite the error
+                } else if (soil.source === 'SoilGrids (NoDataAtLocation)') {
+                    envDataToSet.errorKey = 'soilDataNotAtLocation';
+                } else if (Object.keys(soil).filter(k => k !== 'source' && k !== 'error' && soil[k as keyof typeof soil] !== undefined).length > 0) {
+                    // Assign soil properties only if there are actual data properties
+                    envDataToSet.soilPH = soil.soilPH;
+                    envDataToSet.soilOrganicCarbon = soil.soilOrganicCarbon;
+                    envDataToSet.soilCEC = soil.soilCEC;
+                    envDataToSet.soilNitrogen = soil.soilNitrogen;
+                    envDataToSet.soilSand = soil.soilSand;
+                    envDataToSet.soilSilt = soil.soilSilt;
+                    envDataToSet.soilClay = soil.soilClay;
+                    envDataToSet.soilAWC = soil.soilAWC;
+                } else if (!envDataToSet.errorKey) { // If no specific soil error or NoDataAtLocation was set
+                    envDataToSet.errorKey = 'soilDataUnavailable'; // Soil object exists but is empty or has no usable data
+                }
+            } else { // soil is null or undefined
+                envDataToSet.errorKey = 'soilDataUnavailable';
             }
-            if (!elevation && (!soil || Object.keys(soil).length === 0)) {
-                envDataToSet.errorKey = 'environmentalDataUnavailable';
+
+            // Determine final errorKey based on both elevation and soil states
+            const elevationFailed = !elevation?.elevation;
+            const soilFailedOrUnavailable = envDataToSet.errorKey === 'soilDataUnavailable' ||
+                                          envDataToSet.errorKey === 'soilDataFetchError' ||
+                                          envDataToSet.errorKey === 'soilDataNotAtLocation';
+            const soilHasSpecificError = envDataToSet.errorKey === 'soilDataFetchError' || envDataToSet.errorKey === 'soilDataNotAtLocation';
+
+            if (elevationFailed) {
+                if (soilFailedOrUnavailable && !soilHasSpecificError) {
+                    // Both failed generically, or soil was unavailable and elevation failed
+                    envDataToSet.errorKey = 'environmentalDataUnavailable';
+                } else if (!envDataToSet.errorKey) {
+                    // Soil was successful (or no specific soil error key was set for it), but elevation failed
+                    envDataToSet.errorKey = 'elevationDataUnavailable';
+                }
+                // If soilHasSpecificError, that error key (e.g., 'soilDataFetchError') will persist,
+                // and we don't overwrite it with 'elevationDataUnavailable' or 'environmentalDataUnavailable'.
+                // This prioritizes specific soil errors.
             }
+            // If elevation succeeded but soil failed, the soil error key is already set.
+
             // error field will be populated by the effect below based on errorKey
-            setEnvironmentalData(prev => ({...prev, ...envDataToSet}));
+            setEnvironmentalData(prev => ({...(prev || { dataTimestamp: envDataToSet.dataTimestamp }), ...envDataToSet}));
         }).catch(err => {
-            console.error("Environmental data fetch error in useContextualData:", err);
+            console.error("Environmental data fetch error in useContextualData (Promise.all rejection):", err);
+            // This catch handles errors from Promise.all itself (e.g., if one of the promises rejects immediately)
+            // or if there's an error within the .then() block before setEnvironmentalData.
             setEnvironmentalData({ errorKey: 'environmentalDataUnavailable', dataTimestamp: new Date().toISOString() });
         }).finally(() => setIsLoadingEnvironmental(false));
 
@@ -116,21 +162,32 @@ export function useContextualData(userLocation: UserLocation | null) {
     }
 
     if (environmentalData?.errorKey) {
-      const messageFromUiStrings = uiStrings[environmentalData.errorKey as keyof UiStrings];
-      let localizedErrorMessage: string = typeof messageFromUiStrings === 'function'
-        ? (messageFromUiStrings as (...args: any[]) => string)()
-        : typeof messageFromUiStrings === 'string'
-        ? messageFromUiStrings
-        : String(uiStrings.apiError);
+      let localizedErrorMessage: string;
+      const errorKey = environmentalData.errorKey as keyof UiStrings;
+      const messageTemplate = uiStrings[errorKey];
+
+      if (errorKey === 'soilDataFetchError' && environmentalData.soilErrorDetail) {
+        localizedErrorMessage = typeof messageTemplate === 'function'
+          ? (messageTemplate as (detail: string) => string)(environmentalData.soilErrorDetail)
+          : typeof messageTemplate === 'string'
+          ? messageTemplate.replace('{detail}', environmentalData.soilErrorDetail)
+          : String(uiStrings.apiError);
+      } else {
+        localizedErrorMessage = typeof messageTemplate === 'function'
+          ? (messageTemplate as () => string)()
+          : typeof messageTemplate === 'string'
+          ? messageTemplate
+          : String(uiStrings.apiError);
+      }
       setEnvironmentalData(prev => ({ ...prev!, error: localizedErrorMessage }));
     } else if (environmentalData && environmentalData.errorKey === null && environmentalData.error !== undefined) {
       // Clear error string if errorKey is cleared
       setEnvironmentalData(prev => {
-          const { error, ...rest } = prev!;
+          const { error, soilErrorDetail, ...rest } = prev!; // Also clear soilErrorDetail
           return rest;
       });
     }
-  }, [uiStrings, weatherData?.errorKey, environmentalData?.errorKey, selectedLanguage.code]);
+  }, [uiStrings, weatherData?.errorKey, environmentalData?.errorKey, environmentalData?.soilErrorDetail, selectedLanguage.code]);
 
 
   const handleWeatherTabChange = (tab: 'current' | 'recent' | 'historical', refToFocus: React.RefObject<HTMLButtonElement>) => {


### PR DESCRIPTION
This commit addresses several issues related to location fetching and soil data retrieval:

Location Services:
- Corrected the IP location Next.js API route (`pages/api/ip-location.ts`) by removing an erroneous call to a non-existent backend proxy endpoint. The route now solely relies on direct calls to external IP lookup services (ipapi.co and ip-api.com).
- Refined `hooks/useLocationLogic.ts`:
    - Ensured `userLocation` is explicitly set to `null` during critical failure paths (e.g., if all IP and GPS attempts fail, or if permission queries fail).
    - Standardized the use of the geolocation timeout constant.
    - Added extensive debug logging to trace permission changes, fetch attempts, and final location state.
- Confirmed that `GEOLOCATION_HIGH_ACCURACY_TIMEOUT_MS` is set to a reasonable 10 seconds.

Soil Service:
- Improved error handling in `hooks/useContextualData.ts`:
    - Introduced more specific error keys for different soil data issues (e.g., fetch error, data not available at location, general unavailability).
    - Enabled the display of detailed error messages from the backend soil service proxy.
    - Added distinct error handling for elevation data unavailability.
- Verified that the SoilGrids API timeout in the backend proxy (`fedai-backend-proxy`) is adequate (13 seconds).

General:
- Added debug logging to `pages/api/ip-location.ts` to trace the success/failure of external IP lookup services.

These changes aim to make the location process more robust, provide clearer feedback to you when issues occur, and improve the overall stability of features dependent on location and soil data. The "analyze" button's activity should now more accurately reflect a successful location acquisition.