### PR TITLE
Add fetching-ip state test

### DIFF
--- a/components/LocationSection.test.tsx
+++ b/components/LocationSection.test.tsx
@@ -165,6 +165,23 @@ describe('LocationSection', () => {
     expect(mockFetchDeviceLocation).toHaveBeenCalledTimes(1);
   });
 
+  test('does not render interactive buttons in "fetching-ip" state', () => {
+    mockUseDataContext.mockReturnValue({
+      userLocation: null,
+      locationStatusMessage: 'fetching-ip',
+      locationPermission: 'prompt',
+      isLoadingLocation: true,
+      fetchDeviceLocation: mockFetchDeviceLocation,
+      fetchIpLocationData: mockFetchIpLocationData,
+      // ... other context values
+    });
+
+    render(<LocationSection />);
+    expect(screen.queryByText(defaultUiStrings.shareLocationButton)).not.toBeInTheDocument();
+    expect(screen.queryByText(defaultUiStrings.tryAgainButton)).not.toBeInTheDocument();
+    expect(screen.getByText(defaultUiStrings.locationStatusFetching)).toBeInTheDocument();
+  });
+
   test('does not render interactive buttons in "fetching-gps" state', () => {
     mockUseDataContext.mockReturnValue({
       userLocation: null,


### PR DESCRIPTION
## Summary
- cover LocationSection when fetching IP location

## Testing
- `npx vitest run` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685e7ae77bf4832f832d128be3fd62d1