### PR TITLE
Fix property name for soil silt field

### DIFF
--- a/hooks/useContextualData.ts
+++ b/hooks/useContextualData.ts
@@ -51,10 +51,10 @@ export function useContextualData(userLocation: UserLocation | null) {
             soilCEC: null,
             soilNitrogen: null,
             soilSand: null,
-            silt: null,
+            soilSilt: null,
             soilClay: null,
             soilAWC: null,
-            errorKey: null, 
+            errorKey: null,
             error: undefined
         }));
         

--- a/services/soilService.ts
+++ b/services/soilService.ts
@@ -11,7 +11,7 @@ const PROXY_SOIL_ENDPOINT = '/api/soil';
 
 // This type defines what the fetchSoilDataViaProxy returns and what is cached
 export type SoilDataReturnType = {
-  data?: Partial<Pick<EnvironmentalData, 'soilPH' | 'soilOrganicCarbon' | 'soilCEC' | 'soilNitrogen' | 'soilSand' | 'silt' | 'soilClay' | 'soilAWC'>>;
+  data?: Partial<Pick<EnvironmentalData, 'soilPH' | 'soilOrganicCarbon' | 'soilCEC' | 'soilNitrogen' | 'soilSand' | 'soilSilt' | 'soilClay' | 'soilAWC'>>;
   source?: string;
   dataTimestamp?: string; // From backend success response
   error?: string;         // User-friendly error message from backend


### PR DESCRIPTION
## Summary
- rename the `silt` field to `soilSilt` when resetting `EnvironmentalData`
- align soil service return type with `soilSilt`

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e7ae4301c832f9264ea4ecae638f0