### PR TITLE
Fix Spanish translation typo

### DIFF
--- a/localization.ts
+++ b/localization.ts
@@ -793,7 +793,7 @@ const UI_STRINGS_ES: UiStrings = {
   serviceElevation: "Servicio de Elevación",
   serviceSoil: "Servicio de Datos del Suelo",
   serviceAI: "Servicio de Análisis IA",
-  aiAnalysisInProgressMessage: "El análisis de IA está en curso. Este paso puede tomar unos momentos, especialmente para imágenes complexas o datos contextuales detallados.",
+  aiAnalysisInProgressMessage: "El análisis de IA está en curso. Este paso puede tomar unos momentos, especialmente para imágenes complejas o datos contextuales detallados.",
   solutionEstimatedBudgetLow: "Bajo",
   solutionEstimatedBudgetMedium: "Medio",
   solutionEstimatedBudgetHigh: "Alto",


### PR DESCRIPTION
## Summary
- correct the Spanish translation of `aiAnalysisInProgressMessage`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_685e7ae167e8832fa71d4bd84d8af76c