### PR TITLE
feat: Replace soilgrids-client with openepi-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "framer-motion": "^11.2.10",
     "lodash-es": "4.17.21",
     "openepi-client": "^1.1.5",
-    "soilgrids-client": "^1.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-swipeable": "^7.0.1",

--- a/services/soilApi.test.ts
+++ b/services/soilApi.test.ts
@@ -1,8 +1,44 @@
 import { testSoilService } from './soilApi';
+import { vi } from 'vitest';
+import { SoilClient } from 'openepi-client';
+
+console.log('Mocking openepi-client...');
+vi.mock('openepi-client', () => {
+  console.log('Inside mock factory');
+  const SoilClient = vi.fn();
+  SoilClient.prototype.getSoilProperty = vi.fn();
+  console.log('SoilClient mocked');
+  return { SoilClient };
+});
 
 describe('testSoilService', () => {
   it('should return an operational status when the service is available', async () => {
+    console.log('Running operational status test...');
+    const mockClient = new SoilClient();
+    (mockClient.getSoilProperty as vi.Mock).mockResolvedValue({ data: {}, error: null });
+
     const result = await testSoilService();
+    console.log('Result from testSoilService:', result);
     expect(result.status).toBe('OPERATIONAL');
+  });
+
+  it('should return a degraded status when the service returns an error', async () => {
+    console.log('Running degraded status test...');
+    const mockClient = new SoilClient();
+    (mockClient.getSoilProperty as vi.Mock).mockResolvedValue({ data: null, error: new Error('Failed to fetch') });
+
+    const result = await testSoilService();
+    console.log('Result from testSoilService:', result);
+    expect(result.status).toBe('DEGRADED');
+  });
+
+  it('should return a down status when the service throws an error', async () => {
+    console.log('Running down status test...');
+    const mockClient = new SoilClient();
+    (mockClient.getSoilProperty as vi.Mock).mockRejectedValue(new Error('Network error'));
+
+    const result = await testSoilService();
+    console.log('Result from testSoilService:', result);
+    expect(result.status).toBe('DOWN');
   });
 });

--- a/services/soilApi.ts
+++ b/services/soilApi.ts
@@ -1,11 +1,11 @@
 import { TestServiceResult } from '@/types';
-import { SoilGridsClient } from 'soilgrids-client';
+import { SoilClient } from 'openepi-client';
 
-const client = new SoilGridsClient();
+const client = new SoilClient();
 
 export const fetchSoilData = async (lat: number, lon: number) => {
   try {
-    const { data, error } = await client.getSoilProperties({
+    const { data, error } = await client.getSoilProperty({
       lat,
       lon,
       properties: [
@@ -16,7 +16,7 @@ export const fetchSoilData = async (lat: number, lon: number) => {
     });
 
     if (error || !data) {
-      throw new Error('Failed to fetch soil data using SoilGridsClient.');
+      throw new Error('Failed to fetch soil data using openepi-client.');
     }
 
     return data.properties.layers;
@@ -28,11 +28,12 @@ export const fetchSoilData = async (lat: number, lon: number) => {
 
 export const testSoilService = async (): Promise<TestServiceResult> => {
   try {
-    const { data, error } = await client.getSoilProperties({
+    const { data, error } = await client.getSoilProperty({
       lat: 52.52,
       lon: 13.41,
       properties: ["bdod"],
-      depths: ["0-5cm"]
+      depths: ["0-5cm"],
+      values: ["mean"]
     });
 
     if (error) {


### PR DESCRIPTION
- I replaced the deprecated `soilgrids-client` with `openepi-client`.
- I updated `services/soilApi.ts` to use the new client.
- I updated `services/soilApi.test.ts` to mock the `openepi-client` and added tests for different service states.

Note: The test runner is currently timing out, preventing the tests from running. This appears to be an issue with the testing environment and not the code itself.