### PR TITLE
Add OpenPlantBook proxy endpoint

### DIFF
--- a/FRONTEND_README.md
+++ b/FRONTEND_README.md
@@ -105,7 +105,7 @@ The Fedai frontend application is designed to make API calls to a backend proxy 
 4.  **Use the Application:**
     *   Ensure your Backend Proxy Server is running (e.g., on `http://localhost:3001`).
     *   Open the URL provided by your chosen development server (e.g., `http://localhost:5173` or `http://localhost:3000`) in your browser.
-    *   The frontend will make API calls to relative paths like `/api/gemini-proxy`, `/api/weather`, etc. These are expected to be handled by your running Backend Proxy. The proxy's CORS settings are configured to allow requests from common frontend development ports. If your frontend server uses a different port, you may need to add it to the `corsOptions.origin` array in the backend's `server.js` and restart the proxy.
+    *   The frontend will make API calls to relative paths like `/api/gemini-proxy`, `/api/weather`, `/api/plant/:id`, etc. These are expected to be handled by your running Backend Proxy. The proxy's CORS settings are configured to allow requests from common frontend development ports. If your frontend server uses a different port, you may need to add it to the `corsOptions.origin` array in the backend's `server.js` and restart the proxy.
 
 #### Production Build
 While the `esm.sh/tsx` setup is excellent for simplicity, a typical production deployment involves a build process using Vite.

--- a/fedai-backend-proxy/README.md
+++ b/fedai-backend-proxy/README.md
@@ -39,6 +39,7 @@ Before you begin, ensure you have the following installed on your system:
     *   Add your Google Gemini API key and desired port:
         ```env
         GEMINI_API_KEY=YOUR_ACTUAL_GEMINI_API_KEY_HERE
+        OPEN_PLANTBOOK_API_KEY=YOUR_OPENPLANTBOOK_API_KEY_HERE
         PORT=3001
         # Add other API keys if needed for proxied services
         ```
@@ -75,6 +76,7 @@ The proxy exposes several endpoints under the `/api` path:
 *   **`/api/weather` (POST):** Proxies requests to a weather service.
 *   **`/api/soil` (POST):** Proxies requests to a soil data service.
 *   **`/api/elevation` (POST):** Proxies requests to an elevation service.
+*   **`/api/plant/:id` (GET):** Fetches plant details from the OpenPlantBook API.
 *   **`/api/ip-location` (GET):** Provides approximate location via IP.
 
 Refer to `src/api/routes/` and `src/api/controllers/` for details.

--- a/fedai-backend-proxy/src/api/controllers/data.controller.js
+++ b/fedai-backend-proxy/src/api/controllers/data.controller.js
@@ -10,6 +10,7 @@ const {
   OPEN_ELEVATION_API_URL_PREFIX,
   OPEN_TOPO_DATA_API_URL_PREFIX,
   SOILGRIDS_API_URL_PREFIX,
+  OPEN_PLANTBOOK_API_URL_PREFIX,
   GEOLOCATION_API_TIMEOUT_MS,
 } = require('../utils/constants');
 
@@ -325,10 +326,33 @@ const getSoilData = async (req, res) => {
     }
 };
 
+// --- OpenPlantBook Plant Data Controller ---
+const getPlantData = async (req, res) => {
+    const { id } = req.params;
+    if (!id) {
+        return res.status(400).json({ error: 'Plant ID is required.' });
+    }
+    if (!process.env.OPEN_PLANTBOOK_API_KEY) {
+        return res.status(503).json({ error: 'OpenPlantBook API key not configured on server.' });
+    }
+
+    const plantUrl = `${OPEN_PLANTBOOK_API_URL_PREFIX}${id}/`;
+    try {
+        const data = await robustFetch(plantUrl, {
+            headers: { 'Authorization': `Token ${process.env.OPEN_PLANTBOOK_API_KEY}` }
+        });
+        res.json(data);
+    } catch (error) {
+        console.error(`[PLANTBOOK_API_ERROR] ${error.message}`);
+        res.status(500).json({ error: 'Failed to fetch plant data from OpenPlantBook.' });
+    }
+};
+
 
 module.exports = {
   getIpLocation,
   getWeatherData,
   getElevationData,
   getSoilData,
+  getPlantData,
 };

--- a/fedai-backend-proxy/src/api/routes/data.routes.js
+++ b/fedai-backend-proxy/src/api/routes/data.routes.js
@@ -16,4 +16,7 @@ router.post('/elevation', dataController.getElevationData);
 // Soil Data Route
 router.post('/soil', dataController.getSoilData);
 
+// OpenPlantBook Plant Data Route
+router.get('/plant/:id', dataController.getPlantData);
+
 module.exports = router;

--- a/fedai-backend-proxy/src/api/utils/constants.js
+++ b/fedai-backend-proxy/src/api/utils/constants.js
@@ -7,6 +7,7 @@ const OPEN_METEO_ARCHIVE_API_BASE = 'https://archive-api.open-meteo.com/v1/archi
 const OPEN_ELEVATION_API_URL_PREFIX = 'https://api.open-elevation.com/api/v1/lookup?locations=';
 const OPEN_TOPO_DATA_API_URL_PREFIX = 'https://api.opentopodata.org/v1/etopo1?locations=';
 const SOILGRIDS_API_URL_PREFIX = 'https://soilgrids.org/soilgrids/v2.0/properties/query';
+const OPEN_PLANTBOOK_API_URL_PREFIX = 'https://open.plantbook.io/api/v1/plant/detail/';
 const GEOLOCATION_API_TIMEOUT_MS = 7000;
 
 module.exports = {
@@ -17,5 +18,6 @@ module.exports = {
   OPEN_ELEVATION_API_URL_PREFIX,
   OPEN_TOPO_DATA_API_URL_PREFIX,
   SOILGRIDS_API_URL_PREFIX,
+  OPEN_PLANTBOOK_API_URL_PREFIX,
   GEOLOCATION_API_TIMEOUT_MS,
 };

--- a/services/plantApi.ts
+++ b/services/plantApi.ts
@@ -1,17 +1,11 @@
 import { PlantData } from '../types/api';
 
-export const fetchPlantData = async (plantId: string): Promise<PlantData> => {
-  // The API key MUST be stored securely as an environment variable
-  const API_KEY = process.env.REACT_APP_OPENPLANTBOOK_API_KEY;
-  // IMPORTANT: Note the trailing slash at the end of the URL
-  const url = `https://open.plantbook.io/api/v1/plant/detail/${plantId}/`;
+const PROXY_PLANT_ENDPOINT_PREFIX = '/api/plant';
 
-  const response = await fetch(url, {
-    headers: {
-      // Correct Authentication format as per documentation
-      'Authorization': `Token ${API_KEY}`
-    }
-  });
+export const fetchPlantData = async (plantId: string): Promise<PlantData> => {
+  const url = `${PROXY_PLANT_ENDPOINT_PREFIX}/${plantId}`;
+
+  const response = await fetch(url);
 
   if (!response.ok) {
     throw new Error('Failed to fetch plant data.');


### PR DESCRIPTION
## Summary
- expose `/api/plant/:id` from the backend proxy
- call new proxy route from `plantApi`
- document `OPEN_PLANTBOOK_API_KEY` and new endpoint

## Testing
- `npm test` *(fails: vitest not found / tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_687e69f3a6ac832fab02bd08d5ba8688